### PR TITLE
Fix app title

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import { Inter } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Daylights Smearings',
+  title: 'Daylight Smearings',
   description: 'The healthy and safe way to change clocks',
 }
 


### PR DESCRIPTION
## Summary
- rename the page title in `app/layout.tsx` to "Daylight Smearings"

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_6841261cce0083268fea12e8eea827ed