### PR TITLE
Fix build failure due to Google Font fetch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 
-const inter = Inter({ subsets: ['latin'] })
+// Use the default sans serif font stack instead of fetching fonts from Google.
 
 export const metadata: Metadata = {
   title: 'Daylights Smearings',
@@ -16,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- remove Google font fetch from layout
- use default sans serif fonts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68412595f9d48326922ab2d8d8ea89a0