### PR TITLE
Add email sign-up component with API logging

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const { email } = await request.json()
+  console.log('New signup:', email)
+  return NextResponse.json({ success: true })
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 // app/page.tsx
 
+import EmailSignup from '@/components/EmailSignup'
+
 function Home() {
   return (
     <div className="relative">
@@ -51,15 +53,7 @@ function Home() {
           <p>
             Sign up to be notified of smearing progress and to get our mobile app with smearing alarms.
           </p>
-          {/* Mailing List Signup Form (Placeholder) */}
-          <form className="mt-4">
-            <input
-              type="email"
-              placeholder="Your Email"
-              className="p-2 border border-gray-300 rounded mb-2 w-full"
-            />
-            <button type="submit" className="w-full py-2 bg-blue-600 text-white rounded">Sign Up</button>
-          </form>
+          <EmailSignup />
         </div>
       </section>
     </div>

--- a/components/EmailSignup.tsx
+++ b/components/EmailSignup.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function EmailSignup() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setStatus('Submitting...')
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      if (res.ok) {
+        setStatus('Thanks for signing up!')
+        setEmail('')
+      } else {
+        setStatus('Something went wrong.')
+      }
+    } catch (err) {
+      console.error(err)
+      setStatus('Something went wrong.')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4">
+      <input
+        type="email"
+        placeholder="Your Email"
+        className="p-2 border border-gray-300 rounded mb-2 w-full"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <button type="submit" className="w-full py-2 bg-blue-600 text-white rounded">
+        Sign Up
+      </button>
+      {status && <p className="mt-2 text-sm">{status}</p>}
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- create `<EmailSignup>` component with a POST to `/api/subscribe`
- add `/api/subscribe` route to log provided email
- include component in call-to-action section

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684127db5bf483269ed6d9621703b86a